### PR TITLE
Handle output filenames correctly depending on OS

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 #====================================================
 #     VARIABLES
 #====================================================
-TARGET_EXEC := main.exe
-TEST_EXEC := tests.exe
+TARGET_EXEC := main
+TEST_EXEC := tests
 LIB := libosmanip.a
 CC := g++
 
@@ -42,6 +42,15 @@ LDFLAGS := -pthread
 #     ALIASES
 #====================================================
 .PHONY: clean all
+
+#====================================================
+#     OS DETECTION
+#====================================================
+# Windows (Cygwin)
+ifeq ($(OS), Windows_NT)
+	TARGET_EXEC += .exe
+	TEST_EXEC += .exe
+endif
 
 #====================================================
 #     BUILDING

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+UNAME=$(uname)
+main="bin/main"
+if [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* ]] ; then
+	main="${main}.exe"
+fi
+
 #====================================================
 #     COMPILATION OF THE SOURCE CODE
 #     (check if doctest is installed)
@@ -13,14 +19,14 @@ if [ -f "/usr/include/doctest.h" ] ; then
 elif [ -f "/usr/include/doctest/doctest.h" ] ; then
     echo "Doctest is installed in /usr/include/doctest folder, move it in /usr/include in order to correctly use it for the library tests!"
     echo "Compiling only the main code (this is not a problem for the installation)..."
-    if ! make bin/main ; then
+    if ! make $main ; then
         echo "Compilation failed!"
         exit
     fi
 else
     echo "Doctest is not installed, cannot compile the test codes!"
     echo "Compiling only the main code (this is not a problem for the installation)..."
-    if ! make bin/main ; then
+    if ! make $main ; then
         echo "Compilation failed!"
         exit
     fi


### PR DESCRIPTION
Only add `.exe` to the end of output filenames in `bin` on Windows. This also fixes an issue with `scripts/install.sh` not functioning as it looks for `bin/main` and not `bin/main.exe`.