### PR TITLE
Ensure deps before creating  imported targets

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,6 +1,7 @@
 
 @PACKAGE_INIT@
 
-include ( "${CMAKE_CURRENT_LIST_DIR}/osmanipTargets.cmake" )
 include( CMakeFindDependencyMacro )
 find_dependency( arsenalgear CONFIG )
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/osmanipTargets.cmake" )


### PR DESCRIPTION
If `find_dependency` fails, CMake may look for config in other locations. This can only work well if imported targets are not created before all dependencies are found successfully.